### PR TITLE
fix: gio trash handle long file name fail

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+glib2.0 (2.78.0-2deepin1) unstable; urgency=medium
+
+  * fix gio trash handle long file name fail 
+
+ -- wangrong <wangrong@uniontech.com>  Wed, 01 Nov 2023 10:15:29 +0800
+
 glib2.0 (2.78.0-2) unstable; urgency=medium
 
   * d/p/gthreadedresolver-Fix-race-between-source-callbacks-and-f.patch:

--- a/debian/patches/fix-gio-trash-handle-long-file-name-fail.patch
+++ b/debian/patches/fix-gio-trash-handle-long-file-name-fail.patch
@@ -6,7 +6,7 @@ Description: fix gio trash handle long file name fail
  The solution is to reduce the length of the info file name.
 Author: wangrong1069
 Bug-Deepin: https://github.com/deepin-community/glib2.0/pull/3
-Forwarded: no
+Forwarded: https://gitlab.gnome.org/GNOME/glib/-/merge_requests/3697
 --- glib2.0-2.78.0.orig/gio/glocalfile.c
 +++ glib2.0-2.78.0/gio/glocalfile.c
 @@ -1973,6 +1973,46 @@ _g_local_file_is_lost_found_dir (const c

--- a/debian/patches/fix-gio-trash-handle-long-file-name-fail.patch
+++ b/debian/patches/fix-gio-trash-handle-long-file-name-fail.patch
@@ -1,0 +1,167 @@
+Index: glib2.0-2.78.0/gio/glocalfile.c
+===================================================================
+--- glib2.0-2.78.0.orig/gio/glocalfile.c
++++ glib2.0-2.78.0/gio/glocalfile.c
+@@ -1973,6 +1973,46 @@ _g_local_file_is_lost_found_dir (const c
+ }
+ #endif
+ 
++/**
++ * Truncate the utf8 string by the specified length, and fill the remaining
++ * position with the specified character.
++ */
++static gchar *
++utf8_truncate_by (gchar *src, gsize len, gchar fill)
++{
++  const gchar *endpos, *endptr, *preptr;
++  gsize utf8_len, src_len, dst_len;
++
++  if (!src || !len)
++    return src;
++
++  src_len = strlen (src);
++  if (src_len <= len)
++    {
++      *src = '\0';
++      return src;
++    }
++
++  dst_len = src_len - len;
++  endpos = src + dst_len;
++  preptr = endptr = src;
++  while (endptr <= endpos)
++    {
++      preptr = endptr;
++      endptr = g_utf8_next_char (endptr);
++    }
++
++  utf8_len = preptr - src;
++  while (utf8_len < dst_len)
++    src[utf8_len++] = fill;
++  src[utf8_len] = '\0';
++
++  return src;
++}
++
++#define FILE_NAME_TRUNCATE_STEP 10
++#define FILE_NAME_TRUNCATE_FILL '.'
++
+ static gboolean
+ g_local_file_trash (GFile         *file,
+ 		    GCancellable  *cancellable,
+@@ -1995,6 +2035,7 @@ g_local_file_trash (GFile         *file,
+   GVfsClass *class;
+   GVfs *vfs;
+   int errsv;
++  GError *my_error = NULL;
+ 
+   if (glib_should_use_portal ())
+     return g_trash_portal_trash_file (file, error);
+@@ -2225,37 +2266,89 @@ g_local_file_trash (GFile         *file,
+   i = 1;
+   trashname = NULL;
+   infofile = NULL;
+-  do {
+-    g_free (trashname);
+-    g_free (infofile);
+-    
+-    trashname = get_unique_filename (basename, i++);
+-    infoname = g_strconcat (trashname, ".trashinfo", NULL);
+-    infofile = g_build_filename (infodir, infoname, NULL);
+-    g_free (infoname);
+-
+-    fd = g_open (infofile, O_CREAT | O_EXCL | O_CLOEXEC, 0666);
+-    errsv = errno;
+-  } while (fd == -1 && errsv == EEXIST);
++  while (TRUE)
++    {
++      g_free (trashname);
++      g_free (infofile);
++
++      /* Make sure we can create a unique info file */
++      trashname = get_unique_filename (basename, i++);
++      infoname = g_strconcat (trashname, ".trashinfo", NULL);
++      infofile = g_build_filename (infodir, infoname, NULL);
++      g_free (infoname);
++
++      fd = g_open (infofile, O_CREAT | O_EXCL | O_CLOEXEC, 0666);
++      errsv = errno;
++
++      if (fd == -1)
++        {
++          if (errsv == EEXIST)
++            continue;
++          else if (errsv == ENAMETOOLONG &&
++                   g_utf8_validate (basename, -1, NULL))
++            {
++              utf8_truncate_by (basename,
++                                FILE_NAME_TRUNCATE_STEP,
++                                FILE_NAME_TRUNCATE_FILL);
++              i = 1;
++              continue;
++            }
++          else
++            /* Fd == -1 and file create fail */
++            break;
++        }
++
++      (void) g_close (fd, NULL);
++
++      /* Make sure we can write the info file */
++      if (!g_file_set_contents_full (infofile, NULL, 0,
++                                     G_FILE_SET_CONTENTS_CONSISTENT | G_FILE_SET_CONTENTS_ONLY_EXISTING,
++                                     0600, &my_error))
++        {
++          g_unlink (infofile);
++          if (g_error_matches (my_error,
++                               G_FILE_ERROR,
++                               G_FILE_ERROR_NAMETOOLONG) &&
++              g_utf8_validate (basename, -1, NULL))
++            {
++              g_clear_error (&my_error);
++              utf8_truncate_by (basename,
++                                FILE_NAME_TRUNCATE_STEP,
++                                FILE_NAME_TRUNCATE_FILL);
++              i = 1;
++              continue;
++            }
++          else
++            /* Fd closed and file deleted */
++            break;
++        }
++
++      /* Fd closed and file created */
++      break;
++    }
+ 
+   g_free (basename);
+   g_free (infodir);
+ 
+-  if (fd == -1)
++  if (fd == -1 || my_error)
+     {
+       g_free (filesdir);
+       g_free (topdir);
+       g_free (trashname);
+       g_free (infofile);
+ 
+-      g_set_io_error (error,
+-		      _("Unable to create trashing info file for %s: %s"),
+-                      file, errsv);
++      if (my_error)
++        g_propagate_error (error, my_error);
++      else
++        {
++          g_set_io_error (error,
++                          _("Unable to create trashing info file for %s: %s"),
++                          file, errsv);
++        }
++
+       return FALSE;
+     }
+ 
+-  (void) g_close (fd, NULL);
+-
+   /* Write the full content of the info file before trashing to make
+    * sure someone doesn't read an empty file.  See #749314
+    */

--- a/debian/patches/fix-gio-trash-handle-long-file-name-fail.patch
+++ b/debian/patches/fix-gio-trash-handle-long-file-name-fail.patch
@@ -1,5 +1,12 @@
-Index: glib2.0-2.78.0/gio/glocalfile.c
-===================================================================
+Description: fix gio trash handle long file name fail
+ When gio deletes a file, it will create an info file for the deleted file. The name of the info file is based on the
+ original name with the suffix ".trashinfo" added and uniquely processed. When the name of the deleted file is too
+ long, it will fail to create the info file, or fail to write data to the info file.
+ .
+ The solution is to reduce the length of the info file name.
+Author: wangrong1069
+Bug-Deepin: https://github.com/deepin-community/glib2.0/pull/3
+Forwarded: no
 --- glib2.0-2.78.0.orig/gio/glocalfile.c
 +++ glib2.0-2.78.0/gio/glocalfile.c
 @@ -1973,6 +1973,46 @@ _g_local_file_is_lost_found_dir (const c

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -23,3 +23,4 @@ debian/Add-extra-debug-to-memory-monitor-dbus-test.patch
 debian/tests-Skip-debugcontroller-test.patch
 debian/testfilemonitor-Skip-if-we-are-avoiding-flaky-tests.patch
 debian/gdesktopappinfo-Try-using-x-terminal-emulator-for-Termina.patch
+fix-gio-trash-handle-long-file-name-fail.patch


### PR DESCRIPTION
When gio deletes a file, it will create an info file for the deleted file. The name of the info file is based on the original name with the suffix ".trashinfo" added and uniquely processed. When the name of the deleted file is too long, it will fail to create the info file, or fail to write data to the info file.
The solution is to reduce the length of the info file name.

Log: fix gio trash bug
Bug: https://pms.uniontech.com/bug-view-224677.html