### PR TITLE
fix(gdbusintrospection): Add some assertions before array dereferences

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+glib2.0 (2.80.1-1deepin5) unstable; urgency=medium
+
+  * Backport upstream fixes:
+  * 656ad458: gdbusintrospection: Add some assertions before array
+    dereferences
+
+ -- jiabowen <jiabowen@uniontech.com>  Wed, 27 May 2026 17:36:47 +0800
+
 glib2.0 (2.80.1-1deepin4) unstable; urgency=medium
 
   * Fix: CVE-2025-13601

--- a/debian/patches/gdbusintrospection-assertions-before-deref.patch
+++ b/debian/patches/gdbusintrospection-assertions-before-deref.patch
@@ -1,0 +1,86 @@
+From 656ad4582cb1d7a7fa8bafe3ce8aec6aa3c17da0 Mon Sep 17 00:00:00 2001
+From: Philip Withnall <pwithnall@gnome.org>
+Date: Thu, 16 Apr 2026 15:08:10 +0100
+Subject: [PATCH] gdbusintrospection: Add some assertions before array
+ dereferences
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+The state handling inside the D-Bus introspection XML parser is
+complicated, and it’s possible that these dereferences of the
+`len - 1`th element might get reached when the array is empty.
+
+Make failures like that more debuggable by adding an assertion on the
+length beforehand.
+
+Signed-off-by: Philip Withnall <pwithnall@gnome.org>
+
+Helps: #3932
+
+--- 656ad458.orig/gio/gdbusintrospection.c
++++ 656ad458/gio/gdbusintrospection.c
+@@ -1096,6 +1096,7 @@ parse_data_get_annotation (ParseData *da
+ {
+   if (create_new)
+     g_ptr_array_add (data->annotations, g_new0 (GDBusAnnotationInfo, 1));
++  g_assert (data->annotations->len > 0);
+   return data->annotations->pdata[data->annotations->len - 1];
+ }
+ 
+@@ -1105,6 +1106,7 @@ parse_data_get_arg (ParseData *data,
+ {
+   if (create_new)
+     g_ptr_array_add (data->args, g_new0 (GDBusArgInfo, 1));
++  g_assert (data->args->len > 0);
+   return data->args->pdata[data->args->len - 1];
+ }
+ 
+@@ -1114,6 +1116,7 @@ parse_data_get_out_arg (ParseData *data,
+ {
+   if (create_new)
+     g_ptr_array_add (data->out_args, g_new0 (GDBusArgInfo, 1));
++  g_assert (data->out_args->len > 0);
+   return data->out_args->pdata[data->out_args->len - 1];
+ }
+ 
+@@ -1123,6 +1126,7 @@ parse_data_get_method (ParseData *data,
+ {
+   if (create_new)
+     g_ptr_array_add (data->methods, g_new0 (GDBusMethodInfo, 1));
++  g_assert (data->methods->len > 0);
+   return data->methods->pdata[data->methods->len - 1];
+ }
+ 
+@@ -1132,6 +1136,7 @@ parse_data_get_signal (ParseData *data,
+ {
+   if (create_new)
+     g_ptr_array_add (data->signals, g_new0 (GDBusSignalInfo, 1));
++  g_assert (data->signals->len > 0);
+   return data->signals->pdata[data->signals->len - 1];
+ }
+ 
+@@ -1141,6 +1146,7 @@ parse_data_get_property (ParseData *data
+ {
+   if (create_new)
+     g_ptr_array_add (data->properties, g_new0 (GDBusPropertyInfo, 1));
++  g_assert (data->properties->len > 0);
+   return data->properties->pdata[data->properties->len - 1];
+ }
+ 
+@@ -1150,6 +1156,7 @@ parse_data_get_interface (ParseData *dat
+ {
+   if (create_new)
+     g_ptr_array_add (data->interfaces, g_new0 (GDBusInterfaceInfo, 1));
++  g_assert (data->interfaces->len > 0);
+   return data->interfaces->pdata[data->interfaces->len - 1];
+ }
+ 
+@@ -1159,6 +1166,7 @@ parse_data_get_node (ParseData *data,
+ {
+   if (create_new)
+     g_ptr_array_add (data->nodes, g_new0 (GDBusNodeInfo, 1));
++  g_assert (data->nodes->len > 0);
+   return data->nodes->pdata[data->nodes->len - 1];
+ }
+ 

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -23,3 +23,4 @@ fix-test-timeout.patch
 keep-suffix-name-when-trashing.patch
 0001-CVE-2025-7039.patch
 CVE-2025-13601.patch
+gdbusintrospection-assertions-before-deref.patch


### PR DESCRIPTION
Backport critical fix from upstream glib2.0.

## Patch

- **gdbusintrospection**: Add some assertions before array dereferences
  Upstream: [GNOME/glib@656ad458](https://github.com/GNOME/glib/commit/656ad4582cb1d7a7fa8bafe3ce8aec6aa3c17da0)

## Test Plan

- quilt push -a succeeds cleanly (Debian only)
- dpkg-buildpackage builds successfully (Debian only)