### PR TITLE
fix(gdbusintrospection): Fix XML parser state handling for <node> element nesting

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+glib2.0 (2.80.1-1deepin5) unstable; urgency=medium
+
+  * Backport upstream fixes:
+  * c9da977c: gdbusintrospection: Fix XML parser state handling for
+    <node> element nesting
+
+ -- jiabowen <jiabowen@uniontech.com>  Wed, 27 May 2026 17:39:04 +0800
+
 glib2.0 (2.80.1-1deepin4) unstable; urgency=medium
 
   * Fix: CVE-2025-13601

--- a/debian/patches/gdbusintrospection-fix-xml-parser-state.patch
+++ b/debian/patches/gdbusintrospection-fix-xml-parser-state.patch
@@ -1,0 +1,79 @@
+From c9da977c178fbfc0e4caf99f9fdf5dc433d6fcc2 Mon Sep 17 00:00:00 2001
+From: Philip Withnall <pwithnall@gnome.org>
+Date: Thu, 16 Apr 2026 15:27:37 +0100
+Subject: [PATCH] gdbusintrospection: Fix XML parser state handling for <node>
+ element nesting
+
+The check for whether a `<node>` element in D-Bus introspection XML was
+nested correctly was broken. `<node>` elements can only be at the top
+level, or nested immediately within another `<node>` element.
+
+Fix the check and add some unit tests for it.
+
+Spotted by linhlhq as #YWH-PGM9867-204. The fix is mine, and the unit test
+uses example XML strings adapted from their report.
+
+Signed-off-by: Philip Withnall <pwithnall@gnome.org>
+
+Fixes: #3932
+
+--- c9da977c.orig/gio/gdbusintrospection.c
++++ c9da977c/gio/gdbusintrospection.c
+@@ -1258,7 +1258,7 @@ parser_start_element (GMarkupParseContex
+   /* ---------------------------------------------------------------------------------------------------- */
+   if (strcmp (element_name, "node") == 0)
+     {
+-      if (!(g_slist_length (stack) >= 1 || strcmp (stack->next->data, "node") != 0))
++      if (stack->next != NULL && strcmp (stack->next->data, "node") != 0)
+         {
+           g_set_error_literal (error,
+                                G_MARKUP_ERROR,
+--- c9da977c.orig/gio/tests/gdbus-introspection.c
++++ c9da977c/gio/tests/gdbus-introspection.c
+@@ -299,6 +299,38 @@ test_extra_data (void)
+   g_dbus_node_info_unref (info);
+ }
+ 
++static void
++test_invalid (void)
++{
++  const struct
++    {
++      const char *xml;
++      GMarkupError expected_error_code;
++    }
++  vectors[] =
++    {
++      { "", G_MARKUP_ERROR_EMPTY },
++      { "<node><interface name=\"I\"><method name=\"M\"><node><interface name=\"I2\"></interface></node></method>", G_MARKUP_ERROR_INVALID_CONTENT },
++      { "<node><interface name=\"I\"><signal name=\"S\"><node><interface name=\"I2\"><signal name=\"S2\"></signal></interface></node></signal>", G_MARKUP_ERROR_INVALID_CONTENT },
++      { "<node><interface name=\"I\"><property name=\"P\" type=\"s\" access=\"read\"><node><interface name=\"I2\"></interface></node></property>", G_MARKUP_ERROR_INVALID_CONTENT },
++      { "<node><interface name=\"I\"><method name=\"M\"><arg type=\"\"><node><interface name=\"I2\"><method name=\"M2\"></method></interface></node></arg>", G_MARKUP_ERROR_INVALID_CONTENT },
++    };
++
++  for (size_t i = 0; i < G_N_ELEMENTS (vectors); i++)
++    {
++      GDBusNodeInfo *node;
++      GError *local_error = NULL;
++
++      g_test_message ("Testing parsing of %s gives an error", vectors[i].xml);
++
++      node = g_dbus_node_info_new_for_xml (vectors[i].xml, &local_error);
++      g_assert_error (local_error, G_MARKUP_ERROR, (int) vectors[i].expected_error_code);
++      g_assert_null (node);
++
++      g_clear_error (&local_error);
++    }
++}
++
+ /* ---------------------------------------------------------------------------------------------------- */
+ 
+ int
+@@ -316,6 +348,7 @@ main (int   argc,
+   g_test_add_func ("/gdbus/introspection-generate", test_generate);
+   g_test_add_func ("/gdbus/introspection-default-direction", test_default_direction);
+   g_test_add_func ("/gdbus/introspection-extra-data", test_extra_data);
++  g_test_add_func ("/gdbus/introspection/invalid", test_invalid);
+ 
+   ret = session_bus_run ();
+ 

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -23,3 +23,4 @@ fix-test-timeout.patch
 keep-suffix-name-when-trashing.patch
 0001-CVE-2025-7039.patch
 CVE-2025-13601.patch
+gdbusintrospection-fix-xml-parser-state.patch


### PR DESCRIPTION
Backport critical fix from upstream glib2.0.

## Patch

- **gdbusintrospection**: Fix XML parser state handling for `<node>` element nesting
  Upstream: [GNOME/glib@c9da977c](https://github.com/GNOME/glib/commit/c9da977c178fbfc0e4caf99f9fdf5dc433d6fcc2)

## Test Plan

- quilt push -a succeeds cleanly (Debian only)
- dpkg-buildpackage builds successfully (Debian only)