### PR TITLE
fix(gvariant): Match allocation size of g_slice_new to g_slice_free

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+glib2.0 (2.80.1-1deepin5) unstable; urgency=medium
+
+  * Backport upstream fixes:
+  * 6522dca1: gvariant: Match allocation size of g_slice_new to
+    g_slice_free
+
+ -- jiabowen <jiabowen@uniontech.com>  Wed, 27 May 2026 17:42:26 +0800
+
 glib2.0 (2.80.1-1deepin4) unstable; urgency=medium
 
   * Fix: CVE-2025-13601

--- a/debian/patches/gvariant-fix-slice-alloc-size.patch
+++ b/debian/patches/gvariant-fix-slice-alloc-size.patch
@@ -1,0 +1,27 @@
+From 6522dca1a609cfa2084b979018635e49211919df Mon Sep 17 00:00:00 2001
+From: Simon McVittie <smcv@collabora.com>
+Date: Thu, 23 Apr 2026 15:07:52 +0100
+Subject: [PATCH] gvariant: Match allocation size of g_slice_new to
+ g_slice_free
+
+Commit ebbeb318 "gvariant: Tweak GVariantIter heap allocation size"
+changed the code path that allocates iterators on the heap to use
+the full size of the public iterator struct (including padding),
+but didn't change the matching g_slice_free() call. g_slice_free() is
+implemented as basically g_free_sized(), so the size passed to it
+should match the size that was allocated.
+
+Fixes: ebbeb318 "gvariant: Tweak GVariantIter heap allocation size"
+Signed-off-by: Simon McVittie <smcv@collabora.com>
+
+--- 6522dca1.orig/glib/gvariant.c
++++ 6522dca1/glib/gvariant.c
+@@ -3096,7 +3096,7 @@ g_variant_iter_free (GVariantIter *iter)
+   g_variant_unref (GVHI(iter)->value_ref);
+   GVHI(iter)->magic = 0;
+ 
+-  g_slice_free (struct heap_iter, GVHI(iter));
++  g_slice_free (GVariantIter, iter);
+ }
+ 
+ /**

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -23,3 +23,4 @@ fix-test-timeout.patch
 keep-suffix-name-when-trashing.patch
 0001-CVE-2025-7039.patch
 CVE-2025-13601.patch
+gvariant-fix-slice-alloc-size.patch


### PR DESCRIPTION
Backport critical fix from upstream glib2.0.

## Patch

- **gvariant**: Match allocation size of g_slice_new to g_slice_free
  Upstream: [GNOME/glib@6522dca1](https://github.com/GNOME/glib/commit/6522dca1a609cfa2084b979018635e49211919df)

## Test Plan

- quilt push -a succeeds cleanly (Debian only)
- dpkg-buildpackage builds successfully (Debian only)